### PR TITLE
archive: repo deprecated, all deployments moved to MultiCurrencyWallet

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,21 @@
+# ⚠️ This repository is archived
+
+**All development and deployments have been moved to the main repository:**
+
+👉 **[swaponline/MultiCurrencyWallet](https://github.com/swaponline/MultiCurrencyWallet)**
+
+## What changed
+
+- Plugin is now built and deployed automatically via `deploy.yml` in the main repo
+- Deployment goes directly to production servers via SSH (no longer via this GitHub repo)
+- WordPress plugin ZIP is published to `farm.wpmix.net/updates/` and `growup.wpmix.net`
+
+## For WordPress auto-updates
+
+Plugin updates are served from:
+- `https://farm.wpmix.net/updates/mcw-info.json`
+- `https://growup.wpmix.net/wp-content/uploads/multi-currency-wallet-pro/info.json`
+
+---
+
+*This repository is kept for historical reference only and is no longer updated.*


### PR DESCRIPTION
## This repo is no longer needed

Plugin deployment has been moved to the main repo [swaponline/MultiCurrencyWallet](https://github.com/swaponline/MultiCurrencyWallet) via `deploy.yml` which deploys directly to production servers via SSH.

This PR adds a README explaining the repo is archived. After merging — please **archive this repo** via GitHub Settings → Danger Zone → Archive.

**New deployment targets:**
- `wallet.wpmix.net` — direct SSH rsync
- `growup.wpmix.net` — WP auto-update source  
- `farm.wpmix.net/updates/` — ZIP download